### PR TITLE
Add README for Cos CLI Command Reference and Behavior

### DIFF
--- a/.github/ISSUE_DRAFTS/ux-cos-login-copy-fix.md
+++ b/.github/ISSUE_DRAFTS/ux-cos-login-copy-fix.md
@@ -1,0 +1,40 @@
+# UX: Login hint references `cosine` instead of `cos`
+
+labels: ux, polish
+assignees: 
+
+## Summary
+
+When a user runs `cos` without being logged in, the CLI prints an instruction referencing `cosine login` instead of `cos login`. This can be confusing when only the `cos` binary is installed.
+
+## Current behavior
+
+Exact output:
+```
+You are not logged in. Please run 'cosine login' first.
+```
+
+## Proposed behavior
+
+Replace the message so it references the installed binary name:
+
+```
+You are not logged in. Please run 'cos login' first.
+```
+
+If we officially support the `cosine` alias, we could say:
+```
+You are not logged in. Please run 'cos login' (or 'cosine login') first.
+```
+
+## Context
+
+- Command / area: Default command path (running `cos` with no args, effectively `cos start`)
+- Why this helps: Avoids user confusion when only `cos` is installed
+- Severity: Low
+
+## Acceptance criteria
+
+- [ ] Updated message/help text matches proposal
+- [ ] Any references in docs/help/examples also updated
+- [ ] No change in behavior beyond the copy update

--- a/.github/ISSUE_TEMPLATE/ux-polish.md
+++ b/.github/ISSUE_TEMPLATE/ux-polish.md
@@ -1,0 +1,53 @@
+---
+name: "UX polish"
+about: "Small copy/flow tweaks that improve clarity and consistency"
+title: "UX: "
+labels: ["ux", "polish"]
+assignees: []
+---
+
+## Summary
+
+Briefly describe the UX polish opportunity (copy tweak, message consistency, help text, defaults, etc.).
+
+## Current behavior
+
+What is shown today? Include exact text/screenshots:
+
+```
+(paste exact output)
+```
+
+## Proposed behavior
+
+What should it be instead? Provide exact replacement text and rationale.
+
+```
+(proposed text/output)
+```
+
+## Context
+
+- Command / area:
+- Why this helps:
+- Severity: Low / Medium
+
+## Acceptance criteria
+
+- [ ] Updated message/help text matches proposal
+- [ ] Tests/docs/help examples (if any) updated
+- [ ] No change in behavior beyond copy/UX text
+
+## Example (from this repo)
+
+Current:
+```
+You are not logged in. Please run 'cosine login' first.
+```
+
+Proposed:
+```
+You are not logged in. Please run 'cos login' first.
+```
+
+Rationale: The installed binary name is `cos`, so referencing `cos login` avoids confusion for users who do not have a `cosine` alias installed.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Cos CLI (cos)
+
+This repository contains a decompiled overview of the Cosine CLI binary `cos` and a brief command reference based on observed behavior.
+
+## Command Reference (observed)
+
+- login — Login to the Cosine platform
+- logout — Logout from the Cosine platform
+- serve — Expose a directory to Genie
+  - Flags: `--cwd string="."`, `--project string`, `--verbose`
+- start — Start an interactive CLI session
+  - Flags: `--cwd string="."`, `--project string`, `--log-file string="~/.cosine/cli/debug.log"`, `--simple, -s`
+- diff — Open a side-by-side diff viewer for a unified diff
+  - Flags: `--patch, -p string`, `--task string`, `--cwd string`
+- terminal-setup — Configure VS Code terminal so Shift+Enter inserts a newline
+  - Flags: `--dry-run`, `--print`
+- daemon (hidden) — Serve a grpc server for Genie
+  - Flags: `--cwd string`, `--token int=0`, `--port int=7001`
+
+Global flags: `--help, -h`, `--version, -v`  
+Version observed: `1.0.7`
+
+## Default Behavior
+
+Running `cos` with no arguments attempts to start the interactive session and checks authentication status first.
+
+## Minor UX polish note
+
+- When not logged in, running `cos` prints:
+  - `You are not logged in. Please run 'cosine login' first.`
+- However, the binary name and documented command are `cos`, and the correct command is:
+  - `cos login`
+- Recommendation: Update the message to reference the installed binary name (e.g., `cos login`) or resolve via a symlink/alias if `cosine` is also supported. This avoids confusion for users who only have `cos` installed.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cos CLI (cos)
 
-This repository contains a decompiled overview of the Cosine CLI binary `cos` and a brief command reference based on observed behavior.
+This repository contains a decompiled overview of the Cosine CLI binary `cos` and a complete command reference based on observed behavior and runtime help output.
 
 ## Command Reference (observed)
 
@@ -22,12 +22,119 @@ Version observed: `1.0.7`
 
 ## Default Behavior
 
-Running `cos` with no arguments attempts to start the interactive session and checks authentication status first.
+Running `cos` with no arguments attempts to run the default command (observed: starts the interactive session) and checks authentication status first.
+
+Example output when not logged in:
+```
+You are not logged in. Please run 'cosine login' first.
+```
+
+## Full help output (captured)
+
+Top-level:
+```
+NAME:
+   cos - Work with the Cosine platform and pair with Genie
+
+USAGE:
+   cos [global options] [command [command options]]
+
+VERSION:
+   1.0.7
+
+COMMANDS:
+   login           Login to the Cosine platform
+   logout          Logout from the Cosine platform
+   serve           Expose a directory to Genie
+   start           Start an interactive CLI session
+   diff            Open a side-by-side diff viewer for a unified diff
+   terminal-setup  Configure VS Code terminal so Shift+Enter inserts a newline
+   help, h         Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --help, -h     show help
+   --version, -v  print the version
+```
+
+start:
+```
+NAME:
+   cos start - Start an interactive CLI session
+
+USAGE:
+   cos start [options]
+
+OPTIONS:
+   --cwd string       Directory to expose to Genie. Defaults to current directory. (default: ".")
+   --project string   Cosine project ID.
+   --log-file string  Path to log file (default: ~/.cosine/cli/debug.log)
+   --simple, -s       Enable simple scrollable UI mode (stdout, prompt at bottom) (default: false)
+   --help, -h         show help
+```
+
+serve:
+```
+NAME:
+   cos serve - Expose a directory to Genie
+
+USAGE:
+   cos serve [options]
+
+OPTIONS:
+   --cwd string      Directory to expose to Genie. Defaults to current directory. (default: ".")
+   --project string  Cosine project ID.
+   --verbose         Enable verbose logging. (default: false)
+   --help, -h        show help
+```
+
+daemon (hidden but help-visible):
+```
+NAME:
+   cos daemon - Serve a grpc server for Genie
+
+USAGE:
+   cos daemon [options]
+
+OPTIONS:
+   --cwd string  Directory to expose to Genie. Defaults to current directory.
+   --token int   Cosine authentication token. (default: 0)
+   --port int    Port to serve the grpc server on. (default: 7001)
+   --help, -h    show help
+```
+
+diff:
+```
+NAME:
+   cos diff - Open a side-by-side diff viewer for a unified diff
+
+USAGE:
+   cos diff [options]
+
+OPTIONS:
+   --patch string, -p string  Path to a unified diff (use '-' to read from stdin)
+   --task string              Task ID to fetch and view the full diff for
+   --cwd string               Working directory for resolving relative paths (default: current directory)
+   --help, -h                 show help
+```
+
+terminal-setup:
+```
+NAME:
+   cos terminal-setup - Configure VS Code terminal so Shift+Enter inserts a newline
+
+USAGE:
+   cos terminal-setup [options]
+
+OPTIONS:
+   --dry-run   Print what would be changed but do not modify files (default: false)
+   --print     Print the VS Code keybinding JSON entries (default: false)
+   --help, -h  show help
+```
 
 ## Minor UX polish note
 
 - When not logged in, running `cos` prints:
   - `You are not logged in. Please run 'cosine login' first.`
-- However, the binary name and documented command are `cos`, and the correct command is:
+- However, the installed binary and documented command are `cos`, and the correct command is:
   - `cos login`
-- Recommendation: Update the message to reference the installed binary name (e.g., `cos login`) or resolve via a symlink/alias if `cosine` is also supported. This avoids confusion for users who only have `cos` installed.
+- Recommendation: Update the message to reference the installed binary name (e.g., `cos login`) or support `cosine` via symlink/alias, to avoid confusion when only `cos` is installed.


### PR DESCRIPTION
This PR introduces a README file that provides an overview of the Cosine CLI (`cos`). It includes a detailed command reference based on the observed behavior of the binary, outlining each command's functionality and available flags. Additionally, it describes the default behavior when running `cos` without arguments, as well as a recommendation for improving user experience related to authentication messages. This should help users understand how to effectively use the CLI and clarify the intended commands.

---

> This pull request was co-created with Cosine Genie

Original Task: [Cosine-CLI/6e6hu7nrk9zu](https://cosine.sh/sywt8ah7e7gq/Cosine-CLI/task/6e6hu7nrk9zu)
Author: foxcube3
