### PR TITLE
Add Firefox cookie import functionality and error handling

### DIFF
--- a/cmd/cosine/main.go
+++ b/cmd/cosine/main.go
@@ -14,6 +14,7 @@ func usage() {
 	fmt.Println()
 	fmt.Println("Usage:")
 	fmt.Println("  cosine login-chrome       Import cookies from Chrome for cosine.sh")
+	fmt.Println("  cosine login-firefox      Import cookies from Firefox for cosine.sh")
 	fmt.Println("  cosine whoami             Show stored account info")
 	fmt.Println("  cosine search <query>     Interactive search using ripgrep + fzf")
 }
@@ -33,6 +34,24 @@ func cmdLoginChrome() int {
 		return 1
 	}
 	fmt.Println("Imported cookies from Chrome for cosine.sh")
+	return 0
+}
+
+func cmdLoginFirefox() int {
+	header, err := browserlogin.CookieHeaderForCosineFirefox()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read Firefox cookies: %v\n", err)
+		return 1
+	}
+	cfg := auth.Config{
+		CookieHeader: header,
+		Source:       "firefox",
+	}
+	if err := auth.Save(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to save credentials: %v\n", err)
+		return 1
+	}
+	fmt.Println("Imported cookies from Firefox for cosine.sh")
 	return 0
 }
 
@@ -81,6 +100,8 @@ func main() {
 	switch os.Args[1] {
 	case "login-chrome":
 		os.Exit(cmdLoginChrome())
+	case "login-firefox":
+		os.Exit(cmdLoginFirefox())
 	case "whoami":
 		os.Exit(cmdWhoAmI())
 	case "search":
@@ -92,4 +113,5 @@ func main() {
 		usage()
 		os.Exit(1)
 	}
+}
 }

--- a/internal/browserlogin/browser.go
+++ b/internal/browserlogin/browser.go
@@ -9,29 +9,53 @@ import (
 
 	"github.com/browserutils/kooky"
 	_ "github.com/browserutils/kooky/browser/chrome"
+	_ "github.com/browserutils/kooky/browser/firefox"
 )
 
 // CookieHeaderForCosine gathers non-expired cookies for cosine.sh from Chrome and formats
 // them as a Cookie header string. It searches common Chrome profiles on the system.
+// On some Windows setups with recent Chrome versions, cookie decryption can panic inside
+// the kooky Chrome backend. We defensively recover and return a helpful error instead.
 func CookieHeaderForCosine() (string, error) {
-	// Read cookies from registered Chrome cookie store(s) with filters:
-	// - Valid: non-expired cookies
-	// - DomainHasSuffix: match cosine.sh domains
-	// - Exclude "__Host-CSRF" cookie
-	excludeCSRF := kooky.FilterFunc(func(c *kooky.Cookie) bool {
+	header, err := cookieHeaderForCosineChromeSafe()
+	if err != nil {
+		return "", err
+	}
+	return header, nil
+}
+
+// CookieHeaderForCosineFirefox gathers cookies from Firefox instead of Chrome.
+// Useful as a fallback when Chrome cookie decryption is unavailable on the system.
+func CookieHeaderForCosineFirefox() (string, error) {
+	return cookieHeaderForCosineWithFilters(kooky.DomainHasSuffix(".cosine.sh"), kooky.Valid, excludeCSRFFilter())
+}
+
+func excludeCSRFFilter() kooky.Filter {
+	return kooky.FilterFunc(func(c *kooky.Cookie) bool {
 		return c != nil && c.Name != "__Host-CSRF"
 	})
+}
 
+// cookieHeaderForCosineChromeSafe wraps the Chrome traversal with a recover guard.
+// This avoids crashing the CLI if the underlying library panics during decryption.
+func cookieHeaderForCosineChromeSafe() (header string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("Chrome cookie decryption failed (library panic): %v. Try `cosine login-firefox` or export cookies manually.", r)
+		}
+	}()
+	return cookieHeaderForCosineWithFilters(kooky.DomainHasSuffix(".cosine.sh"), kooky.Valid, excludeCSRFFilter())
+}
+
+// cookieHeaderForCosineWithFilters is the internal logic to aggregate and format cookies.
+func cookieHeaderForCosineWithFilters(filters ...kooky.Filter) (string, error) {
 	seq := kooky.TraverseCookies(
 		context.Background(),
-		kooky.Valid,
-		kooky.DomainHasSuffix(".cosine.sh"),
-		excludeCSRF,
+		filters...,
 	).OnlyCookies()
 
 	var cookies []*kooky.Cookie
 	for c := range seq {
-		// c is *kooky.Cookie
 		if c != nil {
 			cookies = append(cookies, c)
 		}
@@ -52,7 +76,7 @@ func CookieHeaderForCosine() (string, error) {
 	}
 
 	if len(cookies) == 0 {
-		return "", fmt.Errorf("no cosine.sh cookies found in Chrome; ensure you're logged in via Chrome")
+		return "", fmt.Errorf("no cosine.sh cookies found; ensure you're logged in to cosine.sh in the selected browser")
 	}
 
 	// Deduplicate by cookie name (keep latest expires)


### PR DESCRIPTION
This pull request introduces a new command `cosine login-firefox` for importing cookies from Firefox into cosine.sh, providing a fallback option when Chrome cookie decryption fails. 

Key changes made:
- Added a new function `cmdLoginFirefox` that retrieves and saves cookies from Firefox.
- Updated the usage information to include the new command.
- Implemented safer cookie decryption for Chrome that handles potential panic situations by using a recover guard, ensuring a graceful error message is provided if cookie decryption fails.
- Refactored cookie retrieval logic into reusable functions to reduce code duplication and improve maintainability. 

This enhancement improves the user experience by offering an alternative browser option and enhances stability during cookie handling.

---

> This pull request was co-created with Cosine Genie

Original Task: [Cosine-CLI/dn1i1kg3jo4s](https://cosine.sh/sywt8ah7e7gq/Cosine-CLI/task/dn1i1kg3jo4s)
Author: foxcube3
