### PR TITLE
Fix Panic in Chrome Login by Isolating Cookie Retrieval

### DIFF
--- a/cmd/cosine/main.go
+++ b/cmd/cosine/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"cosine-cli/internal/auth"
 	"cosine-cli/internal/browserlogin"
@@ -18,12 +20,42 @@ func usage() {
 	fmt.Println("  cosine search <query>     Interactive search using ripgrep + fzf")
 }
 
-func cmdLoginChrome() int {
+func cmdDumpChromeCookies() int {
 	header, err := browserlogin.CookieHeaderForCosine()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to read Chrome cookies: %v\n", err)
 		return 1
 	}
+	fmt.Print(header)
+	return 0
+}
+
+func cmdLoginChrome() int {
+	// Run cookie retrieval in a subprocess to isolate potential panics
+	self, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "resolve executable: %v\n", err)
+		return 1
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(self, "dump-chrome-cookies")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		// Surface child stderr to aid debugging
+		msg := stderr.String()
+		if msg == "" {
+			msg = err.Error()
+		}
+		fmt.Fprintf(os.Stderr, "failed to read Chrome cookies (subprocess): %s\n", msg)
+		return 1
+	}
+	header := stdout.String()
+	if header == "" {
+		fmt.Fprintf(os.Stderr, "no cookies returned from Chrome\n")
+		return 1
+	}
+
 	cfg := auth.Config{
 		CookieHeader: header,
 		Source:       "chrome",
@@ -81,6 +113,8 @@ func main() {
 	switch os.Args[1] {
 	case "login-chrome":
 		os.Exit(cmdLoginChrome())
+	case "dump-chrome-cookies":
+		os.Exit(cmdDumpChromeCookies())
 	case "whoami":
 		os.Exit(cmdWhoAmI())
 	case "search":


### PR DESCRIPTION
This PR introduces a new command `dump-chrome-cookies` to retrieve Chrome cookies safely in a subprocess. Previously, invoking the cookie retrieval directly in the `cmdLoginChrome()` function led to panics due to input not being full blocks in the AES decryption. By encapsulating the cookie retrieval within a separate command, we isolate potential panics and manage error output more effectively. The main `cmdLoginChrome` now calls this new command, improving both reliability and error handling.

---

> This pull request was co-created with Cosine Genie

Original Task: [Cosine-CLI/pfz4ygxwx437](https://cosine.sh/sywt8ah7e7gq/Cosine-CLI/task/pfz4ygxwx437)
Author: foxcube3
