### PR TITLE
Upgrade kooky dependency to v0.2.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module cosine-cli
 
 go 1.24.7
 
-require github.com/browserutils/kooky v0.2.4
+require github.com/browserutils/kooky v0.2.6
 
 require (
 	github.com/go-sqlite/sqlite3 v0.0.0-20180313105335-53dd8e640ee7 // indirect


### PR DESCRIPTION
This pull request upgrades the kooky dependency from v0.2.4 to v0.2.6. This change is aimed at addressing AES-CBC decryption issues specifically on Windows/Chrome ABE, leveraging improvements made in the newer version of the library.

---

> This pull request was co-created with Cosine Genie

Original Task: [Cosine-CLI/ewnqeh56pd48](https://cosine.sh/sywt8ah7e7gq/Cosine-CLI/task/ewnqeh56pd48)
Author: foxcube3
