### PR TITLE
Fix syntax errors in browser.go

### DIFF
--- a/internal/browserlogin/browser.go
+++ b/internal/browserlogin/browser.go
@@ -10,16 +10,10 @@ import (
 	_ "github.com/browserutils/kooky/browser/all"
 )
 
-// CookieHeaderForCosine gathers non-expired cookies for cosine.sh from Chrome and formats
-// them as a Cookie header string. It searches common Chrome profiles on the system.
-// On some Windows setups with recent Chrome versions, cookie decryption can panic inside
-// the kooky Chrome backend. We defensively recover and return a helpful error instead.
+// CookieHeaderForCosine gathers cookies for cosine.sh from installed browsers
+// via kooky and formats them into a Cookie header string.
 func CookieHeaderForCosine() (string, error) {
-	header, err := cookieHeaderForCosineChromeSafe()
-	if err != nil {
-		return "", err
-	}
-	return header, nil
+	return cookieHeaderForCosineChromeSafe()
 }
 
 func excludeCSRFFilter() kooky.Filter {
@@ -28,16 +22,107 @@ func excludeCSRFFilter() kooky.Filter {
 	})
 }
 
-// cookieHeaderForCosineChromeSafe wraps the Chrome traversal with a recover guard.
-// This avoids crashing the CLI if the underlying library panics during decryption.
+// cookieHeaderForCosineChromeSafe wraps the cookie collection with a recover guard
+// to avoid crashing if the underlying library panics during decryption on some systems.
 func cookieHeaderForCosineChromeSafe() (header string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("Chrome cookie decryption failed (library panic): %v. Consider exporting cookies manually or using another browser.", r)
 		}
 	}()
-	// Use broad filters and manually match domain to avoid suffix handling differences across versions.
 	return cookieHeaderForCosineWithFilters(kooky.Valid, excludeCSRFFilter())
+}
+
+// cookieHeaderForCosineWithFilters is the internal logic to aggregate and format cookies.
+func cookieHeaderForCosineWithFilters(filters ...kooky.Filter) (string, error) {
+	read := kooky.ReadCookies(filters...)
+
+	// Select cookies for cosine.sh and exclude CSRF cookie
+	var cookies []*kooky.Cookie
+	for _, c := range read {
+		if c == nil {
+			continue
+		}
+		d := strings.ToLower(c.Domain)
+		if strings.Contains(d, "cosine.sh") && c.Name != "__Host-CSRF" {
+			cookies = append(cookies, c)
+		}
+	}
+
+	// If still none, try without filters for maximum compatibility.
+	if len(cookies) == 0 {
+		read2 := kooky.ReadCookies()
+		for _, c := range read2 {
+			if c == nil {
+				continue
+			}
+			d := strings.ToLower(c.Domain)
+			if strings.Contains(d, "cosine.sh") && c.Name != "__Host-CSRF" {
+				cookies = append(cookies, c)
+			}
+		}
+	}
+
+	if len(cookies) == 0 {
+		return "", fmt.Errorf("no cosine.sh cookies found; ensure you're logged in to cosine.sh in your browser")
+	}
+
+	// Deduplicate by cookie name (keep latest expires)
+	m := map[string]*kooky.Cookie{}
+	for _, c := range cookies {
+		if c == nil {
+			continue
+		}
+		existing, ok := m[c.Name]
+		if !ok || later(c, existing) {
+			m[c.Name] = c
+		}
+	}
+	names := make([]string, 0, len(m))
+	for n := range m {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	parts := make([]string, 0, len(names))
+	for _, n := range names {
+		parts = append(parts, fmt.Sprintf("%s=%s", n, m[n].Value))
+	}
+	return strings.Join(parts, "; "), nil
+}
+
+func later(a, b *kooky.Cookie) bool {
+	if a == nil || b == nil {
+		return a != nil
+	}
+	ta := a.Expires
+	tb := b.Expires
+	if ta.IsZero() && tb.IsZero() {
+		return true
+	}
+	if ta.IsZero() {
+		return false
+	}
+	if tb.IsZero() {
+		return true
+	}
+	return ta.After(tb)
+}
+
+// IsFreshHeader heuristically checks if the cookie header is likely valid (not empty, not expired-only).
+func IsFreshHeader(header string) bool {
+	return strings.Contains(header, "=") && !strings.Contains(header, "deleted")
+}
+
+// Expired returns true if the cookie is expired (helper, unused externally but kept for clarity)
+func Expired(c *kooky.Cookie) bool {
+	if c == nil {
+		return true
+	}
+	if c.Expires.IsZero() {
+		return false
+	}
+	return time.Now().After(c.Expires)
 }
 </old_code>
 <old_code>


### PR DESCRIPTION
This PR addresses multiple syntax errors found in `browser.go` related to non-declaration statements outside function bodies and unexpected identifiers. The changes include refactoring the cookie handling functions for improved error recovery and clarity. Specifically, I modified the `CookieHeaderForCosine` function to directly return the result of `cookieHeaderForCosineChromeSafe`, added the `cookieHeaderForCosineWithFilters` function to input Cookie filtering logic, and introduced some utility functions to handle cookie expiration checks. These changes ensure better functionality and prevent crashes while fetching cookies for cosine.sh from installed browsers.

---

> This pull request was co-created with Cosine Genie

Original Task: [Cosine-CLI/79avvuwv5k4p](https://cosine.sh/sywt8ah7e7gq/Cosine-CLI/task/79avvuwv5k4p)
Author: foxcube3
